### PR TITLE
Bug Fix: mbedtls_ecdsa_verify_restartable fails with ECDSA_SIGN_ALT

### DIFF
--- a/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
+++ b/ChangeLog.d/mbedtls_ecdsa_can_do-unconditional-define.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an error when MBEDTLS_ECDSA_SIGN_ALT is defined but not
+     MBEDTLS_ECDSA_VERIFY_ALT, causing ecdsa verify to fail. Fixes #7498.

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -234,6 +234,19 @@ cleanup:
 }
 #endif /* ECDSA_DETERMINISTIC || !ECDSA_SIGN_ALT || !ECDSA_VERIFY_ALT */
 
+int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
+{
+    switch (gid) {
+#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
+        case MBEDTLS_ECP_DP_CURVE25519: return 0;
+#endif
+#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
+        case MBEDTLS_ECP_DP_CURVE448: return 0;
+#endif
+        default: return 1;
+    }
+}
+
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message (SEC1 4.1.3)
@@ -371,19 +384,6 @@ cleanup:
     ECDSA_RS_LEAVE(sig);
 
     return ret;
-}
-
-int mbedtls_ecdsa_can_do(mbedtls_ecp_group_id gid)
-{
-    switch (gid) {
-#ifdef MBEDTLS_ECP_DP_CURVE25519_ENABLED
-        case MBEDTLS_ECP_DP_CURVE25519: return 0;
-#endif
-#ifdef MBEDTLS_ECP_DP_CURVE448_ENABLED
-        case MBEDTLS_ECP_DP_CURVE448: return 0;
-#endif
-        default: return 1;
-    }
 }
 
 /*


### PR DESCRIPTION
Copy of pull request:
https://github.com/Mbed-TLS/mbedtls/pull/7499

## Description

When ECDSA_SIGN_ALT but not ECDSA_VERIFY_ALT, mbedtls_ecdsa_can_do was not being defined causing mbedtls_ecdsa_verify_restartable to always fail

Bug in mbedTLS 3 only as `mbedtls_ecdsa_can_do` is not used in mbedTLS 2

Affects [esp-cryptoauthlib](https://github.com/espressif/esp-cryptoauthlib) and [secure_element/atecc608_ecdsa](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/secure_element/atecc608_ecdsa) example if  ATCA_MBEDTLS_ECDSA_SIGN is set and 
ATCA_MBEDTLS_ECDSA_VERIFY is not set

## Gatekeeper checklist

- [x] **changelog** provided, or not required
- [x] **backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

